### PR TITLE
Align license in setup.py with repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     url = 'https://github.com/edsu/luckysocial',
     py_modules = ['luckysocial',],
     description = 'lookup social media accounts for names',
+    license='MIT',
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires = ['requests_html'],


### PR DESCRIPTION
In a similar vein to #1, I noticed the license was not yet denoted on pypi, as specified in setup.py, provided in this PR. Other specifications like Topic, Intended Audience, etc. might help with discoverability for someone looking for the functions exhibited by this tool.